### PR TITLE
Use modifyFileAfterContext() to automatically find and inject after a specific line context

### DIFF
--- a/blitz-app-adblock.js
+++ b/blitz-app-adblock.js
@@ -53,8 +53,8 @@ async function start() {
             else io.copyFile('./build/adblocker.umd.min.js', `${appPath}/app/src/adblocker.umd.min.js`)
     
             // start writing our payload to createWindow.js
-            io.modifyFileAtLine(js.filterEngine, `${appPath}/app/src/createWindow.js`, 275, 'function interceptRequests(windowInstance) {');
-            io.modifyFileAtLine('session: true,', `${appPath}/app/src/createWindow.js`, 107, '');
+            io.modifyFileAfterContext(js.filterEngine, `${appPath}/app/src/createWindow.js`, 'function interceptRequests(windowInstance) {');
+            io.modifyFileAfterContext('session: true,', `${appPath}/app/src/createWindow.js`, 'webPreferences: {');
     
             // optional features
             if (noUpdate)  io.modifyFileAtLine('', `${appPath}/app/src/autoUpdater/index.js`, 46);

--- a/blitz-app-adblock.js
+++ b/blitz-app-adblock.js
@@ -53,7 +53,6 @@ async function start() {
             else io.copyFile('./build/adblocker.umd.min.js', `${appPath}/app/src/adblocker.umd.min.js`)
     
             // start writing our payload to createWindow.js
-            console.log(appPath)
             io.modifyFileAtLine(js.filterEngine, `${appPath}/app/src/createWindow.js`, 275, 'function interceptRequests(windowInstance) {');
             io.modifyFileAtLine('session: true,', `${appPath}/app/src/createWindow.js`, 107, '');
     

--- a/io.js
+++ b/io.js
@@ -44,7 +44,7 @@ function modifyFileAfterContext (data, filePath, context) {
 
   let line = -1
 
-  for (const i = 0; i < file.length; i++) {
+  for (let i = 0; i < file.length; i++) {
     const lineString = file[i]
 
     if (context.trim() === lineString.trim()) {
@@ -108,6 +108,7 @@ function deleteFolder(dir_path) {
 
 module.exports = {
     downloadFile: downloadFile,
+    modifyFileAfterContext: modifyFileAfterContext,
     modifyFileAtLine: modifyFileAtLine,
     copyFile: copyFile,
     deleteFolder: deleteFolder,

--- a/io.js
+++ b/io.js
@@ -39,6 +39,33 @@ async function downloadFile(url, filePath) {
     });
 }
 
+function modifyFileAfterContext (data, filePath, context) {
+  const file = fs.readFileSync(filePath).toString().split('\n')
+
+  let line = -1
+
+  for (const i = 0; i < file.length; i++) {
+    const lineString = file[i]
+
+    if (context.trim() === lineString.trim()) {
+      line = i
+      break
+    }
+  }
+
+  if (line === -1) {
+    throw new Error('Current Blitz version doesn\'t contain the given injection context.')
+  }
+
+  if (file[line + 1] !== data) {
+    file.splice(line + 1, 0, data)
+    const text = file.join('\n')
+
+    fs.writeFileSync(filePath, text)
+    console.log(`${filePath} => Writing to line ${line + 2}: ${data}`)
+  }
+}
+
 function modifyFileAtLine(data, filePath, line, compare=-1) {
     var file = fs.readFileSync(filePath).toString().split("\n");
 

--- a/js.js
+++ b/js.js
@@ -1,6 +1,5 @@
 var filterEngine = 
 `
-function interceptRequests(windowInstance) {
 try {
     const fs = require('fs');
     const { FiltersEngine, Request } = require('./adblocker.umd.min.js');


### PR DESCRIPTION
The point of this is to keep future Blitz updates from preventing the patch because of a failed comparison check.