### PR TITLE
Fix injection context error

### DIFF
--- a/blitz-app-adblock.js
+++ b/blitz-app-adblock.js
@@ -53,7 +53,7 @@ async function start() {
             else io.copyFile('./build/adblocker.umd.min.js', `${appPath}/app/src/adblocker.umd.min.js`)
     
             // start writing our payload to createWindow.js
-            io.modifyFileAfterContext(js.filterEngine, `${appPath}/app/src/createWindow.js`, 'function interceptRequests(windowInstance) {');
+            io.modifyFileAfterContext(js.filterEngine, `${appPath}/app/src/createWindow.js`, 'function interceptRequests() {');
             io.modifyFileAfterContext('session: true,', `${appPath}/app/src/createWindow.js`, 'webPreferences: {');
     
             // optional features

--- a/js.js
+++ b/js.js
@@ -11,7 +11,7 @@ try {
         fs.readFileSync(require.resolve('./peter-lowe-list.txt'), 'utf-8') + '\\ngoogleoptimize.com\\n';
     const engine = FiltersEngine.parse(filters);
 
-    windowInstance.webContents.session.webRequest.onBeforeRequest({ urls: ['*://*/*'] }, (details, callback) => {
+    windows.client.webContents.session.webRequest.onBeforeRequest({ urls: ['*://*/*'] }, (details, callback) => {
         const {match} = engine.match(Request.fromRawDetails({ url: details.url }));
         if (match == true) {
             log.info('BLOCKED:', details.url);


### PR DESCRIPTION
Fix #64 : The `interceptRequests` function no longer takes the `windowsInstance` argument so `io.modifyFileAfterContext` couldn't locate where to make the edit, and subsequently the body of the function uses `windows.client.webContents` instead.

This isn't a fix for #56 , it just gets the patcher itself back to a working state.